### PR TITLE
Added non-default option to build as a shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,6 @@ add_library(mpegts ${libfiles})
 
 
 set_target_properties(mpegts PROPERTIES PUBLIC_HEADER "mpegts/mpegts_demuxer.h;mpegts/mpegts_muxer.h;mpegts/simple_buffer.h;mpegts/ts_packet.h")
-set_target_properties(mpegts PROPERTIES POSITION_INDEPENDENT_CODE ${BUILD_SHARED_LIBS})
 
 add_executable(mpeg_ts_dmx_tests ${CMAKE_CURRENT_SOURCE_DIR}/main_dmx.cpp)
 target_link_libraries(mpeg_ts_dmx_tests mpegts Threads::Threads)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.10)
 project(mpegts)
 set(CMAKE_CXX_STANDARD 17)
 
+option(BUILD_SHARED_LIBS "Build using shared libraries" OFF)
+
 #Macro for printing all CMake variables
 macro(print_all_variables)
     message(STATUS "print_all_variables------------------------------------------{")
@@ -21,7 +23,12 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/mpegts/)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/unit_tests/)
 
 file(GLOB libfiles ${CMAKE_CURRENT_SOURCE_DIR}/mpegts/*.cpp)
-add_library(mpegts STATIC ${libfiles})
+
+add_library(mpegts ${libfiles})
+
+
+set_target_properties(mpegts PROPERTIES PUBLIC_HEADER "mpegts/mpegts_demuxer.h;mpegts/mpegts_muxer.h;mpegts/simple_buffer.h;mpegts/ts_packet.h")
+set_target_properties(mpegts PROPERTIES POSITION_INDEPENDENT_CODE ${BUILD_SHARED_LIBS})
 
 add_executable(mpeg_ts_dmx_tests ${CMAKE_CURRENT_SOURCE_DIR}/main_dmx.cpp)
 target_link_libraries(mpeg_ts_dmx_tests mpegts Threads::Threads)
@@ -32,3 +39,8 @@ target_link_libraries(mpeg_ts_mx_tests mpegts Threads::Threads)
 file(GLOB unit_tests_sources ${CMAKE_CURRENT_SOURCE_DIR}/unit_tests/*.cpp)
 add_executable(mpeg_ts_unit_tests ${unit_tests_sources} ${CMAKE_CURRENT_SOURCE_DIR}/unit_tests.cpp)
 target_link_libraries(mpeg_ts_unit_tests mpegts Threads::Threads)
+
+install(TARGETS mpegts
+        LIBRARY DESTINATION lib        
+        PUBLIC_HEADER DESTINATION include/mpegts
+        )


### PR DESCRIPTION
First off, nice work on this!

I'm using it as part of a larger project and wanted it as a shared library. Since you're currently building as a static, I left that as the default. This shouldn't make any difference for you, but it's convenient for me and perhaps others to have the option.