### PR TITLE
STAR-1132: Fix random access indicator bug in demuxer

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -14,11 +14,14 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: get the ts test file
-      run: wget https://github.com/andersc/assets/raw/master/bars.ts
-    - name: build and run
+      run: |
+        wget https://github.com/andersc/assets/raw/master/bars.ts
+    - name: build unit tests
       run: |
         mkdir build
         cd build
         cmake -DCMAKE_BUILD_TYPE=Release ..
         cmake --build . --config Release --target mpeg_ts_unit_tests
-        ./mpeg_ts_unit_tests 
+    - name: run unit tests
+      run: |
+        build/mpeg_ts_unit_tests 

--- a/main_dmx.cpp
+++ b/main_dmx.cpp
@@ -44,7 +44,7 @@ void dmxOutput(const EsFrame &esFrame) {
 
                 std::string aFilename;
                 std::ostringstream aFilenameBld;
-                aFilenameBld << "../bars_dmx/af" << aFrameCounter++ << ".adts";
+                aFilenameBld << "bars_dmx/af" << aFrameCounter++ << ".adts";
                 aFilename = aFilenameBld.str();
                 std::cout << " Filename: " << aFilename  << std::endl;
                 std::ofstream oAFile(aFilename, std::ofstream::binary | std::ofstream::out);
@@ -57,7 +57,7 @@ void dmxOutput(const EsFrame &esFrame) {
 
             std::string vFilename;
             std::ostringstream vFilenameBld;
-            vFilenameBld << "../bars_dmx/vf" << vFrameCounter << ".h264";
+            vFilenameBld << "bars_dmx/vf" << vFrameCounter << ".h264";
             vFilename = vFilenameBld.str();
             std::cout << " Filename: " << vFilename  << std::endl;
             std::ofstream oVFile(vFilename, std::ofstream::binary | std::ofstream::out);
@@ -66,7 +66,7 @@ void dmxOutput(const EsFrame &esFrame) {
 
             std::string ptsDtsFilename;
             std::ostringstream ptsDtsFilenameBld;
-            ptsDtsFilenameBld << "../bars_dmx/ptsdts" << vFrameCounter++ << ".txt";
+            ptsDtsFilenameBld << "bars_dmx/ptsdts" << vFrameCounter++ << ".txt";
             ptsDtsFilename = ptsDtsFilenameBld.str();
             std::cout << " Filename: " << ptsDtsFilename  << std::endl;
             std::ofstream oPtsDtsFile(ptsDtsFilename);
@@ -87,7 +87,7 @@ void dmxOutput(const EsFrame &esFrame) {
 int main(int argc, char *argv[]) {
     std::cout << "TS - demuxlib test " << std::endl;
     gDemuxer.esOutCallback = std::bind(&dmxOutput, std::placeholders::_1);
-    std::ifstream ifile("../bars.ts", std::ios::binary | std::ios::in);
+    std::ifstream ifile("bars.ts", std::ios::binary | std::ios::in);
     uint8_t packet[188] = {0};
     SimpleBuffer in;
 

--- a/main_dmx.cpp
+++ b/main_dmx.cpp
@@ -15,18 +15,18 @@ MpegTsDemuxer gDemuxer;
 int aFrameCounter = {1};
 int vFrameCounter = {1};
 
-void dmxOutput(const EsFrame *pEs) {
+void dmxOutput(const EsFrame &esFrame) {
 
-        if (pEs->mStreamType == TYPE_AUDIO) {
-            std::cout << " AAC Frame, PID: " << unsigned(pEs->mPid) << " PTS:" << unsigned(pEs->mPts) << std::endl;
+        if (esFrame.mStreamType == TYPE_AUDIO) {
+            std::cout << " AAC Frame, PID: " << unsigned(esFrame.mPid) << " PTS:" << unsigned(esFrame.mPts) << std::endl;
             size_t lDataPointer = 0;
 
             //Break out the individual ADTS frames
             do {
-                uint8_t b1= pEs->mData->data()[lDataPointer];
-                uint8_t b2= pEs->mData->data()[lDataPointer+1] & 0xf0;
+                uint8_t b1= esFrame.mData->data()[lDataPointer];
+                uint8_t b2= esFrame.mData->data()[lDataPointer + 1] & 0xf0;
                 if (b1 == 0xff && b2 == 0xf0) {
-                    if ((pEs->mData->data()[lDataPointer+1] & 0x08)) {
+                    if ((esFrame.mData->data()[lDataPointer + 1] & 0x08)) {
                         std::cout << std::endl;
                         std::cout << "Error -> Not MPEG-4 ADTS Audio " << std::endl;
                         break;
@@ -37,9 +37,9 @@ void dmxOutput(const EsFrame *pEs) {
                     break;
                 }
 
-                b1 = pEs->mData->data()[lDataPointer+3] & 0x3;
-                b2 = pEs->mData->data()[lDataPointer+4];
-                uint8_t b3 = pEs->mData->data()[lDataPointer+5];
+                b1 = esFrame.mData->data()[lDataPointer + 3] & 0x3;
+                b2 = esFrame.mData->data()[lDataPointer + 4];
+                uint8_t b3 = esFrame.mData->data()[lDataPointer + 5];
                 uint32_t lLength = (((uint32_t)b1 << 16) | ((uint32_t)b2 << 8) | (uint32_t)b3) >> 5;
 
                 std::string aFilename;
@@ -48,12 +48,12 @@ void dmxOutput(const EsFrame *pEs) {
                 aFilename = aFilenameBld.str();
                 std::cout << " Filename: " << aFilename  << std::endl;
                 std::ofstream oAFile(aFilename, std::ofstream::binary | std::ofstream::out);
-                oAFile.write((const char *)pEs->mData->data()+lDataPointer,lLength);
+                oAFile.write((const char *)esFrame.mData->data() + lDataPointer, lLength);
                 oAFile.close();
                 lDataPointer += lLength;
-            } while (lDataPointer < pEs->mData->size());
-        } else if (pEs->mStreamType == TYPE_VIDEO_H264) {
-            std::cout << " H.264 , PID: " << unsigned(pEs->mPid)  << " PTS:" << unsigned(pEs->mPts) << " DTS:" << unsigned(pEs->mDts) << std::endl;
+            } while (lDataPointer < esFrame.mData->size());
+        } else if (esFrame.mStreamType == TYPE_VIDEO_H264) {
+            std::cout << " H.264 , PID: " << unsigned(esFrame.mPid) << " PTS:" << unsigned(esFrame.mPts) << " DTS:" << unsigned(esFrame.mDts) << std::endl;
 
             std::string vFilename;
             std::ostringstream vFilenameBld;
@@ -61,7 +61,7 @@ void dmxOutput(const EsFrame *pEs) {
             vFilename = vFilenameBld.str();
             std::cout << " Filename: " << vFilename  << std::endl;
             std::ofstream oVFile(vFilename, std::ofstream::binary | std::ofstream::out);
-            oVFile.write((const char *)pEs->mData->data(),pEs->mData->size());
+            oVFile.write((const char *)esFrame.mData->data(), esFrame.mData->size());
             oVFile.close();
 
             std::string ptsDtsFilename;
@@ -70,16 +70,16 @@ void dmxOutput(const EsFrame *pEs) {
             ptsDtsFilename = ptsDtsFilenameBld.str();
             std::cout << " Filename: " << ptsDtsFilename  << std::endl;
             std::ofstream oPtsDtsFile(ptsDtsFilename);
-            oPtsDtsFile << std::to_string(pEs->mPts) << std::endl;
-            oPtsDtsFile << std::to_string(pEs->mDts) << std::endl;
+            oPtsDtsFile << std::to_string(esFrame.mPts) << std::endl;
+            oPtsDtsFile << std::to_string(esFrame.mDts) << std::endl;
             oPtsDtsFile.close();
 
 
-        } else if (pEs->mStreamType == TYPE_VIDEO_H265) {
-            std::cout << " H.265 frame, PID: " << unsigned(pEs->mPid)  << std::endl;
+        } else if (esFrame.mStreamType == TYPE_VIDEO_H265) {
+            std::cout << " H.265 frame, PID: " << unsigned(esFrame.mPid) << std::endl;
         } else {
-            std::cout << " streamType: " << unsigned(pEs->mStreamType) << " streamId: "
-                      << unsigned(pEs->mStreamId) << " PID:" << unsigned(pEs->mPid)  << std::endl;
+            std::cout << " streamType: " << unsigned(esFrame.mStreamType) << " streamId: "
+                      << unsigned(esFrame.mStreamId) << " PID:" << unsigned(esFrame.mPid) << std::endl;
         }
 
 }

--- a/main_mx.cpp
+++ b/main_mx.cpp
@@ -14,7 +14,7 @@
 #define SAVE_TO_FILE
 #ifdef SAVE_TO_FILE
 #define SAVED_TS_NUM_SECONDS 25
-std::ofstream oMpegTs("../output.ts", std::ofstream::binary | std::ofstream::out);
+std::ofstream oMpegTs("output.ts", std::ofstream::binary | std::ofstream::out);
 int savedOutputSeconds = {0};
 bool savingFrames = {true};
 bool closeOnce = {false};
@@ -110,7 +110,7 @@ void fakeAudioEncoder() {
 
             std::string aFilename;
             std::ostringstream aFilenameBld;
-            aFilenameBld << "../bars_dmx/af" << lFrameCounter+1 << ".adts";
+            aFilenameBld << "bars_dmx/af" << lFrameCounter+1 << ".adts";
             aFilename = aFilenameBld.str();
             //std::cout << " Filename: " << aFilename  << std::endl;
 
@@ -179,13 +179,13 @@ void fakeVideoEncoder() {
 
             std::string vFilename;
             std::ostringstream vFilenameBld;
-            vFilenameBld << "../bars_dmx/vf" << lFrameCounter+1 << ".h264";
+            vFilenameBld << "bars_dmx/vf" << lFrameCounter+1 << ".h264";
             vFilename = vFilenameBld.str();
             //std::cout << " Filename: " << vFilename  << std::endl;
 
             std::string ptsDtsFilename;
             std::ostringstream ptsDtsFilenameBld;
-            ptsDtsFilenameBld << "../bars_dmx/ptsdts" << lFrameCounter+1 << ".txt";
+            ptsDtsFilenameBld << "bars_dmx/ptsdts" << lFrameCounter+1 << ".txt";
             ptsDtsFilename = ptsDtsFilenameBld.str();
 
             std::ifstream thisPtsFile(ptsDtsFilename);
@@ -262,10 +262,10 @@ int main(int argc, char *argv[]) {
 
     std::string lStartPTS;
     std::string lEndPTS;
-    std::ifstream startPtsFile("../bars_dmx/ptsdts1.txt");
+    std::ifstream startPtsFile("bars_dmx/ptsdts1.txt");
     std::getline(startPtsFile, lStartPTS);
     startPtsFile.close();
-    std::ifstream endPtsFile("../bars_dmx/ptsdts1201.txt");
+    std::ifstream endPtsFile("bars_dmx/ptsdts1201.txt");
     std::getline(endPtsFile, lEndPTS);
     endPtsFile.close();
     std::stringstream frst(lStartPTS);

--- a/mpegts/mpegts_demuxer.h
+++ b/mpegts/mpegts_demuxer.h
@@ -23,7 +23,7 @@ public:
 
     uint8_t decode(SimpleBuffer &rIn);
 
-    std::function<void(const EsFrame *pEs)> esOutCallback = nullptr;
+    std::function<void(const EsFrame& pEs)> esOutCallback = nullptr;
     std::function<void(uint64_t lPcr)> pcrOutCallback = nullptr;
     std::function<void(const std::string&)> streamInfoCallback = nullptr;
 
@@ -41,7 +41,7 @@ public:
 
 private:
     // pid, Elementary data frame
-    std::map<int, std::shared_ptr<EsFrame>> mEsFrames;
+    std::map<int, EsFrame> mEsFrames;
     int mPcrId;
     SimpleBuffer mRestData;
 };

--- a/mpegts/ts_packet.cpp
+++ b/mpegts/ts_packet.cpp
@@ -8,8 +8,8 @@ EsFrame::EsFrame()
     mData.reset(new SimpleBuffer);
 }
 
-EsFrame::EsFrame(uint8_t lSt)
-        : mStreamType(lSt), mPid(0), mExpectedPesPacketLength(0), mExpectedPayloadLength(0), mCompleted(false), mBroken(false) {
+EsFrame::EsFrame(uint8_t streamType, uint16_t pid)
+        : mStreamType(streamType), mPid(pid), mExpectedPesPacketLength(0), mExpectedPayloadLength(0), mCompleted(false), mBroken(false) {
     mData.reset(new SimpleBuffer);
 }
 
@@ -18,7 +18,6 @@ bool EsFrame::empty() {
 }
 
 void EsFrame::reset() {
-    mPid = 0;
     mCompleted = false;
     mBroken = false;
     mExpectedPesPacketLength = 0;

--- a/mpegts/ts_packet.h
+++ b/mpegts/ts_packet.h
@@ -18,7 +18,7 @@ class EsFrame {
 public:
     EsFrame();
 
-    EsFrame(uint8_t lSt);
+    EsFrame(uint8_t streamType, uint16_t pid);
 
     virtual ~EsFrame() {};
 

--- a/unit_tests/unit_test_1.cpp
+++ b/unit_tests/unit_test_1.cpp
@@ -34,22 +34,22 @@
 //Test Vector size
 #define TEST_VECTOR_SIZE 4000
 
-void UnitTest1::dmxOutput(const EsFrame *pEs){
+void UnitTest1::dmxOutput(const EsFrame& esFrame) {
 
     //Is the frame correctly marked as mRandomAccess
-    if ((mFrameCounter%10)?0:1 != pEs->mRandomAccess) {
-        std::cout << "mRandomAccess indication error: " << unsigned(pEs->mRandomAccess) << " Frame -> " << unsigned(mFrameCounter) << std::endl;
+    if ((mFrameCounter%10)?0: 1 != esFrame.mRandomAccess) {
+        std::cout << "mRandomAccess indication error: " << unsigned(esFrame.mRandomAccess) << " Frame -> " << unsigned(mFrameCounter) << std::endl;
         mUnitTestStatus = false;
     }
 
     //verify expected size
-    if (pEs->mData->size() != mFrameCounter ) {
-        std::cout << "Frame size missmatch " << unsigned(pEs->mData->size()) << std::endl;
+    if (esFrame.mData->size() != mFrameCounter ) {
+        std::cout << "Frame size missmatch " << unsigned(esFrame.mData->size()) << std::endl;
         mUnitTestStatus = false;
     }
 
     //Make sure PTS and DTS are set as expected
-    if (pEs->mPts != mFrameCounter ||  pEs->mDts != mFrameCounter) {
+    if (esFrame.mPts != mFrameCounter || esFrame.mDts != mFrameCounter) {
         std::cout << "PTS - DTS" << std::endl;
         mUnitTestStatus = false;
     }
@@ -57,9 +57,9 @@ void UnitTest1::dmxOutput(const EsFrame *pEs){
     uint8_t referenceVector = 0;
     //verify expected vector
     for (int lI = 0 ; lI < mFrameCounter ; lI++) {
-        if (pEs->mData->data()[lI] != referenceVector++ ) {
+        if (esFrame.mData->data()[lI] != referenceVector++ ) {
             std::cout << "Content missmatch for packet size -> " << unsigned(mFrameCounter) << " at byte: " << unsigned(lI);
-            std::cout << " Expected " << unsigned(referenceVector -1 ) << " got " << (uint8_t)pEs->mData->data()[lI] + 0 << std::endl;
+            std::cout << " Expected " << unsigned(referenceVector -1 ) << " got " << (uint8_t)esFrame.mData->data()[lI] + 0 << std::endl;
             mUnitTestStatus = false;
         }
     }

--- a/unit_tests/unit_test_1.h
+++ b/unit_tests/unit_test_1.h
@@ -14,7 +14,7 @@ public:
     bool runTest();
 private:
     void muxOutput(SimpleBuffer &rTsOutBuffer);
-    void dmxOutput(const EsFrame *pEs);
+    void dmxOutput(const EsFrame& esFrame);
 
     MpegTsDemuxer mDemuxer;
     int mFrameCounter = 1;

--- a/unit_tests/unit_test_2.cpp
+++ b/unit_tests/unit_test_2.cpp
@@ -34,22 +34,22 @@
 //Test Vector size
 #define TEST_VECTOR_SIZE 4000
 
-void UnitTest2::dmxOutput(const EsFrame *pEs){
+void UnitTest2::dmxOutput(const EsFrame& esFrame){
 
     //Is the frame correctly marked as mRandomAccess
-    if ((mFrameCounter%10)?0:1 != pEs->mRandomAccess) {
-        std::cout << "mRandomAccess indication error: " << unsigned(pEs->mRandomAccess) << " Frame -> " << unsigned(mFrameCounter) << std::endl;
+    if ((mFrameCounter%10)?0: 1 != esFrame.mRandomAccess) {
+        std::cout << "mRandomAccess indication error: " << unsigned(esFrame.mRandomAccess) << " Frame -> " << unsigned(mFrameCounter) << std::endl;
         mUnitTestStatus = false;
     }
 
     //verify expected size
-    if (pEs->mData->size() != mFrameCounter ) {
-        std::cout << "Frame size missmatch " << unsigned(pEs->mData->size()) << std::endl;
+    if (esFrame.mData->size() != mFrameCounter ) {
+        std::cout << "Frame size missmatch " << unsigned(esFrame.mData->size()) << std::endl;
         mUnitTestStatus = false;
     }
 
     //Make sure PTS and DTS are set as expected
-    if (pEs->mPts != mFrameCounter ||  pEs->mDts != mFrameCounter) {
+    if (esFrame.mPts != mFrameCounter || esFrame.mDts != mFrameCounter) {
         std::cout << "PTS - DTS" << std::endl;
         mUnitTestStatus = false;
     }
@@ -57,9 +57,9 @@ void UnitTest2::dmxOutput(const EsFrame *pEs){
     uint8_t referenceVector = 0;
     //verify expected vector
     for (int lI = 0 ; lI < mFrameCounter ; lI++) {
-        if (pEs->mData->data()[lI] != referenceVector++ ) {
+        if (esFrame.mData->data()[lI] != referenceVector++ ) {
             std::cout << "Content missmatch for packet size -> " << unsigned(mFrameCounter) << " at byte: " << unsigned(lI);
-            std::cout << " Expected " << unsigned(referenceVector -1 ) << " got " << (uint8_t)pEs->mData->data()[lI] + 0 << std::endl;
+            std::cout << " Expected " << unsigned(referenceVector -1 ) << " got " << (uint8_t)esFrame.mData->data()[lI] + 0 << std::endl;
             mUnitTestStatus = false;
         }
     }

--- a/unit_tests/unit_test_2.h
+++ b/unit_tests/unit_test_2.h
@@ -14,7 +14,7 @@ public:
     bool runTest();
 private:
     void muxOutput(SimpleBuffer &rTsOutBuffer);
-    void dmxOutput(const EsFrame *pEs);
+    void dmxOutput(const EsFrame& esFrame);
 
     MpegTsDemuxer mDemuxer;
     int mFrameCounter = 1;

--- a/unit_tests/unit_test_3.cpp
+++ b/unit_tests/unit_test_3.cpp
@@ -36,22 +36,22 @@
 //Test Vector size
 #define TEST_VECTOR_SIZE 4000
 
-void UnitTest3::dmxOutput(const EsFrame *pEs){
+void UnitTest3::dmxOutput(const EsFrame &esFrame){
 
     //Is the frame correctly marked as mRandomAccess
-    if ((mFrameCounter%10)?0:1 != pEs->mRandomAccess) {
-        std::cout << "mRandomAccess indication error: " << unsigned(pEs->mRandomAccess) << " Frame -> " << unsigned(mFrameCounter) << std::endl;
+    if ((mFrameCounter%10)?0: 1 != esFrame.mRandomAccess) {
+        std::cout << "mRandomAccess indication error: " << unsigned(esFrame.mRandomAccess) << " Frame -> " << unsigned(mFrameCounter) << std::endl;
         mUnitTestStatus = false;
     }
 
     //verify expected size
-    if (pEs->mData->size() != mFrameCounter ) {
-        std::cout << "Frame size missmatch got: " << unsigned(pEs->mData->size()) << " Expected: " << unsigned(mFrameCounter) << std::endl;
+    if (esFrame.mData->size() != mFrameCounter ) {
+        std::cout << "Frame size missmatch got: " << unsigned(esFrame.mData->size()) << " Expected: " << unsigned(mFrameCounter) << std::endl;
         mUnitTestStatus = false;
     }
 
     //Make sure PTS and DTS are set as expected
-    if (pEs->mPts != (mFrameCounter+1) ||  pEs->mDts != mFrameCounter) {
+    if (esFrame.mPts != (mFrameCounter + 1) || esFrame.mDts != mFrameCounter) {
         std::cout << "PTS - DTS" << std::endl;
         mUnitTestStatus = false;
     }
@@ -59,9 +59,9 @@ void UnitTest3::dmxOutput(const EsFrame *pEs){
     uint8_t referenceVector = 0;
     //verify expected vector
     for (int lI = 0 ; lI < mFrameCounter ; lI++) {
-        if (pEs->mData->data()[lI] != referenceVector++ ) {
+        if (esFrame.mData->data()[lI] != referenceVector++ ) {
             std::cout << "Content missmatch for packet size -> " << unsigned(mFrameCounter) << " at byte: " << unsigned(lI);
-            std::cout << " Expected " << unsigned(referenceVector -1 ) << " got " << (uint8_t)pEs->mData->data()[lI] + 0 << std::endl;
+            std::cout << " Expected " << unsigned(referenceVector -1 ) << " got " << (uint8_t)esFrame.mData->data()[lI] + 0 << std::endl;
             mUnitTestStatus = false;
         }
     }

--- a/unit_tests/unit_test_3.h
+++ b/unit_tests/unit_test_3.h
@@ -14,7 +14,7 @@ public:
     bool runTest();
 private:
     void muxOutput(SimpleBuffer &rTsOutBuffer);
-    void dmxOutput(const EsFrame *pEs);
+    void dmxOutput(const EsFrame &esFrame);
 
     MpegTsDemuxer mDemuxer;
     int mFrameCounter = 1;

--- a/unit_tests/unit_test_4.cpp
+++ b/unit_tests/unit_test_4.cpp
@@ -36,22 +36,22 @@
 //Test Vector size
 #define TEST_VECTOR_SIZE 4000
 
-void UnitTest4::dmxOutput(const EsFrame *pEs){
+void UnitTest4::dmxOutput(const EsFrame& esFrame){
 
     //Is the frame correctly marked as mRandomAccess
-    if ((mFrameCounter%10)?0:1 != pEs->mRandomAccess) {
-        std::cout << "mRandomAccess indication error: " << unsigned(pEs->mRandomAccess) << " Frame -> " << unsigned(mFrameCounter) << std::endl;
+    if ((mFrameCounter%10)?0: 1 != esFrame.mRandomAccess) {
+        std::cout << "mRandomAccess indication error: " << unsigned(esFrame.mRandomAccess) << " Frame -> " << unsigned(mFrameCounter) << std::endl;
         mUnitTestStatus = false;
     }
 
     //verify expected size
-    if (pEs->mData->size() != mFrameCounter ) {
-        std::cout << "Frame size missmatch " << unsigned(pEs->mData->size()) << std::endl;
+    if (esFrame.mData->size() != mFrameCounter ) {
+        std::cout << "Frame size missmatch " << unsigned(esFrame.mData->size()) << std::endl;
         mUnitTestStatus = false;
     }
 
     //Make sure PTS and DTS are set as expected
-    if (pEs->mPts != mFrameCounter ||  pEs->mDts != mFrameCounter) {
+    if (esFrame.mPts != mFrameCounter || esFrame.mDts != mFrameCounter) {
         std::cout << "PTS - DTS" << std::endl;
         mUnitTestStatus = false;
     }
@@ -59,9 +59,9 @@ void UnitTest4::dmxOutput(const EsFrame *pEs){
     uint8_t referenceVector = 0;
     //verify expected vector
     for (int lI = 0 ; lI < mFrameCounter ; lI++) {
-        if (pEs->mData->data()[lI] != referenceVector++ ) {
+        if (esFrame.mData->data()[lI] != referenceVector++ ) {
             std::cout << "Content missmatch for packet size -> " << unsigned(mFrameCounter) << " at byte: " << unsigned(lI);
-            std::cout << " Expected " << unsigned(referenceVector -1 ) << " got " << (uint8_t)pEs->mData->data()[lI] + 0 << std::endl;
+            std::cout << " Expected " << unsigned(referenceVector -1 ) << " got " << (uint8_t)esFrame.mData->data()[lI] + 0 << std::endl;
             mUnitTestStatus = false;
         }
     }

--- a/unit_tests/unit_test_4.h
+++ b/unit_tests/unit_test_4.h
@@ -14,7 +14,7 @@ public:
     bool runTest();
 private:
     void muxOutput(SimpleBuffer &rTsOutBuffer);
-    void dmxOutput(const EsFrame *pEs);
+    void dmxOutput(const EsFrame &esFrame);
 
     MpegTsDemuxer mDemuxer;
     int mFrameCounter = 1;

--- a/unit_tests/unit_test_5.cpp
+++ b/unit_tests/unit_test_5.cpp
@@ -72,17 +72,17 @@ uint8_t tsPacket2[TS_PACKET_SIZE] =
 
 #include "unit_test_5.h"
 
-void UnitTest5::dmxOutput(const EsFrame *pEs){
+void UnitTest5::dmxOutput(const EsFrame &esFrame){
 
-    if (mPacketLength != pEs->mData->size()) {
+    if (mPacketLength != esFrame.mData->size()) {
         std::cout << "Content length mismatch. Expected:" << unsigned(mPacketLength) << " bytes" << std::endl;
     }
 
     uint8_t referenceVector = 0;
     //verify expected vector
-    for (int lI = 0 ; lI < pEs->mData->size() ; lI++) {
-        if (pEs->mData->data()[lI] != referenceVector++ ) {
-            std::cout << "Content mismatch. Expected:" << unsigned(lI) << " Got: " << (uint8_t)pEs->mData->data()[lI] + 0 << std::endl;
+    for (int lI = 0 ; lI < esFrame.mData->size() ; lI++) {
+        if (esFrame.mData->data()[lI] != referenceVector++ ) {
+            std::cout << "Content mismatch. Expected:" << unsigned(lI) << " Got: " << (uint8_t)esFrame.mData->data()[lI] + 0 << std::endl;
             mUnitTestStatus = false;
         }
     }

--- a/unit_tests/unit_test_5.h
+++ b/unit_tests/unit_test_5.h
@@ -13,7 +13,7 @@ class UnitTest5 {
 public:
     bool runTest();
 
-    void dmxOutput(const EsFrame *pEs);
+    void dmxOutput(const EsFrame &esFrame);
     bool mFrameInTransit = false;
     bool mUnitTestStatus = true;
     int mPacketLength = 0;

--- a/unit_tests/unit_test_6.cpp
+++ b/unit_tests/unit_test_6.cpp
@@ -37,13 +37,13 @@ void UnitTest6::dmxOutputPcr(uint64_t lPcr) {
     }
 }
 
-void UnitTest6::dmxOutputPtsDts(const EsFrame *pEs) {
-    if (mPts != pEs->mPts) {
+void UnitTest6::dmxOutputPtsDts(const EsFrame &esFrame) {
+    if (mPts != esFrame.mPts) {
         std::cout << "PTS mismatch." << std::endl;
         mUnitTestStatus = false;
     }
 
-    if (mDts != pEs->mDts) {
+    if (mDts != esFrame.mDts) {
         std::cout << "DTS mismatch." << std::endl;
         mUnitTestStatus = false;
     }
@@ -51,7 +51,7 @@ void UnitTest6::dmxOutputPtsDts(const EsFrame *pEs) {
     uint8_t referenceVector = 0;
     //verify expected vector
     for (int lI = 0 ; lI < TEST_VECTOR_SIZE ; lI++) {
-        if (pEs->mData->data()[lI] != referenceVector++ ) {
+        if (esFrame.mData->data()[lI] != referenceVector++ ) {
             std::cout << "Content missmatch." << std::endl;
             mUnitTestStatus = false;
         }
@@ -60,16 +60,16 @@ void UnitTest6::dmxOutputPtsDts(const EsFrame *pEs) {
     mFrameInTransit = false;
 }
 
-void UnitTest6::dmxOutputPts(const EsFrame *pEs){
+void UnitTest6::dmxOutputPts(const EsFrame &esFrame){
 
-    if (mPts != pEs->mPts) {
+    if (mPts != esFrame.mPts) {
         std::cout << "PTS missmatch." << std::endl;
     }
 
     uint8_t referenceVector = 0;
     //verify expected vector
     for (int lI = 0 ; lI < TEST_VECTOR_SIZE ; lI++) {
-        if (pEs->mData->data()[lI] != referenceVector++ ) {
+        if (esFrame.mData->data()[lI] != referenceVector++ ) {
             std::cout << "Content missmatch." << std::endl;
             mUnitTestStatus = false;
         }

--- a/unit_tests/unit_test_6.h
+++ b/unit_tests/unit_test_6.h
@@ -14,8 +14,8 @@ public:
     bool runTest();
 private:
     void muxOutput(SimpleBuffer &rTsOutBuffer);
-    void dmxOutputPts(const EsFrame *pEs);
-    void dmxOutputPtsDts(const EsFrame *pEs);
+    void dmxOutputPts(const EsFrame &esFrame);
+    void dmxOutputPtsDts(const EsFrame &esFrame);
     void dmxOutputPcr(uint64_t lPcr);
 
     MpegTsDemuxer mDemuxer;

--- a/unit_tests/unit_test_7.cpp
+++ b/unit_tests/unit_test_7.cpp
@@ -10,7 +10,7 @@
 void UnitTest7::dmxOutputPcr(uint64_t lPcr) {
 }
 
-void UnitTest7::dmxOutput(const EsFrame *pEs){
+void UnitTest7::dmxOutput(const EsFrame &esFrame){
     mFrameCounter ++;
     mUnitTestStatus = true;
 }

--- a/unit_tests/unit_test_7.cpp
+++ b/unit_tests/unit_test_7.cpp
@@ -24,7 +24,7 @@ bool UnitTest7::runTest() {
     mDemuxer.esOutCallback = std::bind(&UnitTest7::dmxOutput, this, std::placeholders::_1);
     mDemuxer.pcrOutCallback = std::bind(&UnitTest7::dmxOutputPcr, this, std::placeholders::_1);
 
-    std::ifstream lFile("../bars.ts", std::ios::binary | std::ios::in);
+    std::ifstream lFile("bars.ts", std::ios::binary | std::ios::in);
     uint8_t lPacket[300] = {0};
     SimpleBuffer lIn;
 

--- a/unit_tests/unit_test_7.h
+++ b/unit_tests/unit_test_7.h
@@ -13,7 +13,7 @@ class UnitTest7 {
 public:
     bool runTest();
 private:
-    void dmxOutput(const EsFrame *pEs);
+    void dmxOutput(const EsFrame &esFrame);
     void dmxOutputPcr(uint64_t lPcr);
 
     MpegTsDemuxer mDemuxer;


### PR DESCRIPTION
**The issue was when PES headers didn't specify the length of the PES packet, which is valid (for video streams) and the case for my testing, I do think it is pretty common**
Previously the first frame would get RAI=0, and following frames the RAI of the coming frame rather than the actual frame.