### PR TITLE
STAR-1176: Use a 64 bit integer instead of 32 to reach the highest 33…

### DIFF
--- a/mpegts/common.cpp
+++ b/mpegts/common.cpp
@@ -25,7 +25,7 @@ void writePts(SimpleBuffer &rSb, uint32_t lFb, uint64_t lPts) {
 
 uint64_t readPts(SimpleBuffer &rSb) {
     uint64_t lPts = 0;
-    uint32_t lVal = 0;
+    uint64_t lVal = 0;
     lVal = rSb.read1Byte();
     lPts |= ((lVal >> 1) & 0x07) << 30;
 


### PR DESCRIPTION
… bit

PTS/DTS are 33 bits, needed to store read values in a 64 bit integer in order to shift it to bits 33-31.